### PR TITLE
master <- feature/7/add-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: ruby
+gemfile: 
+    - meal-planner/Gemfile
+before_install:
+    - gem update --system
+    - gem install bundler
+before_script: 
+    - cd meal-planner
+script: 
+    - bundle exec rails test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # meal-planner
 A Ruby-on-Rails app for managing recipes and periodic shopping lists
 
+[![Build Status](https://travis-ci.org/truggeri/meal-planner.svg?branch=master)](https://travis-ci.org/truggeri/meal-planner)
+
 ## Overview
 
 This app is a Ruby-on-Rails (RoR) app. The purpose of the app is keep recipes with their ingredients. While there are a number of sites that do this, the idea here is to provide a service that will put together a shopping list and meal plan for the week to minimize the ammount of shopping and prep time. The end result is an app that users will rely on to maximize their time efficiency while cooking at home.


### PR DESCRIPTION
Closes #7 

Adds support for [Travis ci](https://travis-ci.org/truggeri/meal-planner/) ([free tier - .org](https://travis-ci.org/)) using a travis yaml file (`.travis.yml`). This file sets the following:

* Language is ruby. The version is set with the `.ruby-version` file.
* Sets the `Gemfile` location because it's not in the root directory
* Upgrades bundler to use 2.0
* Sets the build to occur in the `meal-planner` directory
* Runs `bundle exec rails test` as the "build" command

I also added the build badge for master on in the top level README.md